### PR TITLE
Use `HeaderByNumber` instead of `BlockByNumber`

### DIFF
--- a/pkg/chain/ethereum/block_counter.go
+++ b/pkg/chain/ethereum/block_counter.go
@@ -219,7 +219,7 @@ func CreateBlockCounter(chainReader ChainReader) (*BlockCounter, error) {
 	if err != nil {
 		return nil,
 			fmt.Errorf(
-				"failed to get initial block from the chain: [%v]",
+				"failed to get initial block header from the chain: [%v]",
 				err,
 			)
 	}

--- a/pkg/chain/ethereum/block_counter.go
+++ b/pkg/chain/ethereum/block_counter.go
@@ -201,12 +201,12 @@ func (bc *BlockCounter) subscribeBlocks(
 		}
 	}()
 
-	lastBlock, err := chainReader.BlockByNumber(ctx, nil)
+	lastHeader, err := chainReader.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return err
 	}
 
-	bc.subscriptionChannel <- block{lastBlock.Number.String()}
+	bc.subscriptionChannel <- block{lastHeader.Number.String()}
 
 	return nil
 }
@@ -215,7 +215,7 @@ func (bc *BlockCounter) subscribeBlocks(
 func CreateBlockCounter(chainReader ChainReader) (*BlockCounter, error) {
 	ctx := context.Background()
 
-	startupBlock, err := chainReader.BlockByNumber(ctx, nil)
+	startupHeader, err := chainReader.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return nil,
 			fmt.Errorf(
@@ -225,7 +225,7 @@ func CreateBlockCounter(chainReader ChainReader) (*BlockCounter, error) {
 	}
 
 	blockCounter := &BlockCounter{
-		latestBlockHeight:   startupBlock.Number.Uint64(),
+		latestBlockHeight:   startupHeader.Number.Uint64(),
 		waiters:             make(map[uint64][]chan uint64),
 		subscriptionChannel: make(chan block),
 	}

--- a/pkg/chain/ethereum/chain.go
+++ b/pkg/chain/ethereum/chain.go
@@ -39,6 +39,10 @@ type Subscription interface {
 
 // ChainReader provides access to the blockchain.
 type ChainReader interface {
+	// HeaderByNumber gets the block header by its number. The block header
+	// number argument can be nil to select the latest block header.
+	HeaderByNumber(ctx context.Context, number *big.Int) (*Header, error)
+
 	// BlockByNumber gets the block by its number. The block number argument
 	// can be nil to select the latest block.
 	BlockByNumber(ctx context.Context, number *big.Int) (*Block, error)

--- a/pkg/chain/ethereum/chain.go
+++ b/pkg/chain/ethereum/chain.go
@@ -43,10 +43,6 @@ type ChainReader interface {
 	// number argument can be nil to select the latest block header.
 	HeaderByNumber(ctx context.Context, number *big.Int) (*Header, error)
 
-	// BlockByNumber gets the block by its number. The block number argument
-	// can be nil to select the latest block.
-	BlockByNumber(ctx context.Context, number *big.Int) (*Block, error)
-
 	// SubscribeNewHead subscribes to notifications about changes of the
 	// head block of the canonical chain.
 	SubscribeNewHead(

--- a/pkg/chain/ethereum/ethutil/adapter.go
+++ b/pkg/chain/ethereum/ethutil/adapter.go
@@ -28,22 +28,6 @@ func (ea *ethereumAdapter) HeaderByNumber(
 	}, nil
 }
 
-func (ea *ethereumAdapter) BlockByNumber(
-	ctx context.Context,
-	number *big.Int,
-) (*chainEthereum.Block, error) {
-	block, err := ea.delegate.BlockByNumber(ctx, number)
-	if err != nil {
-		return nil, err
-	}
-
-	return &chainEthereum.Block{
-		Header: &chainEthereum.Header{
-			Number: block.Number(),
-		},
-	}, nil
-}
-
 func (ea *ethereumAdapter) SubscribeNewHead(
 	ctx context.Context,
 	headersChan chan<- *chainEthereum.Header,

--- a/pkg/chain/ethereum/ethutil/adapter.go
+++ b/pkg/chain/ethereum/ethutil/adapter.go
@@ -14,6 +14,20 @@ type ethereumAdapter struct {
 	delegate EthereumClient
 }
 
+func (ea *ethereumAdapter) HeaderByNumber(
+	ctx context.Context,
+	number *big.Int,
+) (*chainEthereum.Header, error) {
+	header, err := ea.delegate.HeaderByNumber(ctx, number)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chainEthereum.Header{
+		Number: header.Number,
+	}, nil
+}
+
 func (ea *ethereumAdapter) BlockByNumber(
 	ctx context.Context,
 	number *big.Int,

--- a/pkg/chain/ethereum/ethutil/adapter_test.go
+++ b/pkg/chain/ethereum/ethutil/adapter_test.go
@@ -64,55 +64,6 @@ func TestEthereumAdapter_HeaderByNumber(t *testing.T) {
 	}
 }
 
-func TestEthereumAdapter_BlockByNumber(t *testing.T) {
-	client := &mockAdaptedEthereumClient{
-		blocks: []*big.Int{
-			big.NewInt(0),
-			big.NewInt(1),
-			big.NewInt(2),
-		},
-		blocksBaseFee: []*big.Int{
-			big.NewInt(10),
-			big.NewInt(11),
-			big.NewInt(12),
-		},
-	}
-
-	adapter := &ethereumAdapter{client}
-
-	blockOne, err := adapter.BlockByNumber(context.Background(), big.NewInt(1))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lastBlock, err := adapter.BlockByNumber(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedBlockOneNumber := big.NewInt(1)
-	if expectedBlockOneNumber.Cmp(blockOne.Number) != 0 {
-		t.Errorf(
-			"unexpected block number\n"+
-				"expected: [%v]\n"+
-				"actual:   [%v]",
-			expectedBlockOneNumber,
-			blockOne.Number,
-		)
-	}
-
-	expectedLastBlockNumber := big.NewInt(2)
-	if expectedLastBlockNumber.Cmp(lastBlock.Number) != 0 {
-		t.Errorf(
-			"unexpected last block number\n"+
-				"expected: [%v]\n"+
-				"actual:   [%v]",
-			expectedLastBlockNumber,
-			lastBlock.Number,
-		)
-	}
-}
-
 func TestEthereumAdapter_SubscribeNewHead(t *testing.T) {
 	ctx, cancelCtx := context.WithTimeout(
 		context.Background(),


### PR DESCRIPTION
This PR replaces usage of `BlockByNumber` with `HeaderByNumber`.
This is needed because the Pectra Ethereum update introduced [new type of transaction](https://eips.ethereum.org/EIPS/eip-4844) and the version of `go-ethereum` we use cannot handle them.
If a block contains a transaction of the new type, the `BlockCounter` would complain that the transaction type is not supported. The easiest fix is to use `HeaderByNumber` as it still works fine.